### PR TITLE
Fix/ex4.4

### DIFF
--- a/04_http/README.md
+++ b/04_http/README.md
@@ -24,7 +24,7 @@ Tips:
 
 ## Exercice 4.4
 
-Créer un fichier `run-04.js` pour renvoyer [le logo sfeir](https://www.sfeir.com/content/themes/sfeir/img/logos/logo-sfeir-noir.svg) en réponse à une requête `GET` sur `/sfeir`
+Créer un fichier `run-04.js` pour renvoyer [le logo google](https://www.google.fr/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png) en réponse à une requête `GET` sur `/google`
 
 Tips:
 

--- a/04_http/correction.run-04.js
+++ b/04_http/correction.run-04.js
@@ -10,8 +10,8 @@ const server = http.createServer((req, res) => {
 
     res.setHeader('Content-Type', 'image/png');
 
-    https.get(options, res2 => {
-      res2
+    https.get(options, logoResponse => {
+      logoResponse
         .on('data', function(chunk) {
           res.write(chunk);
         })

--- a/04_http/correction.run-04.js
+++ b/04_http/correction.run-04.js
@@ -3,11 +3,12 @@ const https = require('https');
 const url = require('url');
 
 const server = http.createServer((req, res) => {
-  if (req.url === '/sfeir') {
-    const logo = 'https://www.sfeir.com/content/themes/sfeir/img/logos/logo-sfeir-noir.svg';
+  if (req.url === '/google') {
+    const logo =
+      'https://www.google.fr/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png';
     const options = url.parse(logo);
 
-    res.setHeader('Content-Type', 'application/xml');
+    res.setHeader('Content-Type', 'image/png');
 
     https.get(options, (res2) => {
       res2.on('data', function (chunk) {

--- a/04_http/correction.run-04.js
+++ b/04_http/correction.run-04.js
@@ -10,18 +10,18 @@ const server = http.createServer((req, res) => {
 
     res.setHeader('Content-Type', 'image/png');
 
-    https.get(options, (res2) => {
-      res2.on('data', function (chunk) {
-        res.write(chunk);
-      });
-
-      res2.on('end', function() {
-        res.end();
-      })
+    https.get(options, res2 => {
+      res2
+        .on('data', function(chunk) {
+          res.write(chunk);
+        })
+        .on('end', function() {
+          res.end();
+        });
     });
   } else if (req.url === '/404') {
     res.statusCode = 404;
-    res.end('Pas trouvé !')
+    res.end('Pas trouvé !');
   } else {
     res.end(`Kikou ! Tu as fait un ${req.method} sur ${req.url} !`);
   }


### PR DESCRIPTION
- change /sfeir to /google and send Google logo instead of the SFEIR one (dead link) to stay consistent with the slides (and have something that works)
- update the exercise's README
- show that `.on` calls can be chained on streams

![](https://media.giphy.com/media/3o6Zt62PeJeFUDwBUI/giphy.gif)